### PR TITLE
Use 'react-jsx' JSX transformer instead of 'react'

### DIFF
--- a/client/components/foo-list.test.tsx
+++ b/client/components/foo-list.test.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { act, render, screen, waitFor } from '@testing-library/react';
 import fooListFn from './foo-list'
 import {afterEach, expect, jest, describe, it} from '@jest/globals'

--- a/client/components/foo-list.tsx
+++ b/client/components/foo-list.tsx
@@ -1,4 +1,4 @@
-import React, {
+import {
   type FC,
   type ReactElement,
   useState,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
-    "jsx": "react",
+    "jsx": "react-jsx",
     "module": "es6",
     "moduleResolution": "node",
     "noImplicitAny": true,


### PR DESCRIPTION
This makes it so you don't need to `import React from 'react'` in every file that uses JSX. The React docs also claim this newer transformer has performance improvements.

Also removed the now unnecessary React imports.

https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html