### PR TITLE
fix the boolean check for PGSSLMODE

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -8,7 +8,7 @@ dotenv.config()
 
 const pool = new pg.Pool({
   connectionString: process.env.DATABASE_URL,
-  ssl: Boolean(process.env.PGSSLMODE) && { rejectUnauthorized: false },
+  ssl: process.env.PGSSLMODE == 'true' && { rejectUnauthorized: false },
 });
 
 pool.on('connect', () => console.log('🐘 Postgres connected'));


### PR DESCRIPTION
I've tested that this works when PGSSLMODE is not set at all, it's set to false, it's set to true, and it all behaves as expected (with only `true` turning on SSL mode).